### PR TITLE
feat: 后端校验与文档完善

### DIFF
--- a/backend/src/headline/dto/generate-headline.dto.ts
+++ b/backend/src/headline/dto/generate-headline.dto.ts
@@ -1,4 +1,13 @@
-import { IsString, IsOptional, IsIn, MinLength, MaxLength } from 'class-validator';
+import {
+  IsString,
+  IsOptional,
+  IsIn,
+  MinLength,
+  MaxLength,
+  IsInt,
+  Min,
+  Max,
+} from 'class-validator';
 
 /**
  * 生成标题请求DTO
@@ -25,7 +34,8 @@ export class GenerateHeadlineDto {
    */
   @IsOptional()
   @IsIn(['youtube', 'tiktok', 'instagram', 'twitter', 'blog', 'general'], {
-    message: '平台类型必须是: youtube, tiktok, instagram, twitter, blog, general 之一',
+    message:
+      '平台类型必须是: youtube, tiktok, instagram, twitter, blog, general 之一',
   })
   platform?: string;
 
@@ -34,7 +44,8 @@ export class GenerateHeadlineDto {
    */
   @IsOptional()
   @IsIn(['professional', 'casual', 'humorous', 'dramatic', 'informative'], {
-    message: '语调风格必须是: professional, casual, humorous, dramatic, informative 之一',
+    message:
+      '语调风格必须是: professional, casual, humorous, dramatic, informative 之一',
   })
   tone?: string;
 
@@ -42,6 +53,9 @@ export class GenerateHeadlineDto {
    * 生成数量（可选，默认5个）
    */
   @IsOptional()
+  @IsInt({ message: '生成数量必须是整数' })
+  @Min(1, { message: '生成数量不能小于1' })
+  @Max(20, { message: '生成数量不能超过20' })
   count?: number = 5;
 }
 

--- a/backend/src/headline/headline.controller.ts
+++ b/backend/src/headline/headline.controller.ts
@@ -1,6 +1,9 @@
 import { Controller, Post, Body, ValidationPipe } from '@nestjs/common';
 import { HeadlineService } from './headline.service';
-import { GenerateHeadlineDto, HeadlineResponseDto } from './dto/generate-headline.dto';
+import {
+  GenerateHeadlineDto,
+  HeadlineResponseDto,
+} from './dto/generate-headline.dto';
 
 /**
  * 标题生成器控制器
@@ -27,7 +30,7 @@ export class HeadlineController {
    * @returns {object} 服务状态
    */
   @Post('health')
-  async healthCheck(): Promise<{ status: string; timestamp: string }> {
+  healthCheck(): { status: string; timestamp: string } {
     return {
       status: 'ok',
       timestamp: new Date().toISOString(),

--- a/backend/src/headline/headline.service.ts
+++ b/backend/src/headline/headline.service.ts
@@ -1,6 +1,9 @@
 import { Injectable, BadRequestException } from '@nestjs/common';
 import { ConfigService } from '../config/config.service';
-import { GenerateHeadlineDto, HeadlineResponseDto } from './dto/generate-headline.dto';
+import {
+  GenerateHeadlineDto,
+  HeadlineResponseDto,
+} from './dto/generate-headline.dto';
 
 /**
  * 标题生成器服务
@@ -14,52 +17,66 @@ export class HeadlineService {
    * @param {GenerateHeadlineDto} dto - 生成标题的请求参数
    * @returns {Promise<HeadlineResponseDto>} 生成的标题响应
    */
-  async generateHeadlines(dto: GenerateHeadlineDto): Promise<HeadlineResponseDto> {
+  async generateHeadlines(
+    dto: GenerateHeadlineDto,
+  ): Promise<HeadlineResponseDto> {
     const apiKey = this.configService.openaiApiKey;
-    
+
     if (!apiKey) {
-      throw new BadRequestException('OpenAI API密钥未配置，请检查环境变量OPENAI_API_KEY');
+      throw new BadRequestException(
+        'OpenAI API密钥未配置，请检查环境变量OPENAI_API_KEY',
+      );
     }
 
     try {
       // 构建提示词
       const prompt = this.buildPrompt(dto);
-      
+
       // 调用OpenAI API
-      const response = await fetch('https://api.openai.com/v1/chat/completions', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${apiKey}`,
+      const response = await fetch(
+        'https://api.openai.com/v1/chat/completions',
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${apiKey}`,
+          },
+          body: JSON.stringify({
+            model: 'gpt-3.5-turbo',
+            messages: [
+              {
+                role: 'system',
+                content:
+                  '你是一个专业的内容创作助手，擅长为不同平台生成吸引人的标题。请根据用户的要求生成标题，每个标题单独一行。',
+              },
+              {
+                role: 'user',
+                content: prompt,
+              },
+            ],
+            max_tokens: 500,
+            temperature: 0.8,
+          }),
         },
-        body: JSON.stringify({
-          model: 'gpt-3.5-turbo',
-          messages: [
-            {
-              role: 'system',
-              content: '你是一个专业的内容创作助手，擅长为不同平台生成吸引人的标题。请根据用户的要求生成标题，每个标题单独一行。',
-            },
-            {
-              role: 'user',
-              content: prompt,
-            },
-          ],
-          max_tokens: 500,
-          temperature: 0.8,
-        }),
-      });
+      );
 
       if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(`OpenAI API错误: ${errorData.error?.message || '未知错误'}`);
+        const errorData = (await response.json()) as {
+          error?: { message?: string };
+        };
+        throw new Error(
+          `OpenAI API错误: ${errorData.error?.message ?? '未知错误'}`,
+        );
       }
 
-      const data = await response.json();
-      const content = data.choices[0]?.message?.content || '';
-      
+      const data = (await response.json()) as {
+        choices: Array<{ message?: { content?: string } }>;
+      };
+      const content = data.choices[0]?.message?.content ?? '';
+
       // 解析生成的标题
       const headlines = this.parseHeadlines(content, dto.count || 5);
-      
+
       return {
         headlines,
         timestamp: new Date().toISOString(),
@@ -71,9 +88,10 @@ export class HeadlineService {
           count: dto.count || 5,
         },
       };
-    } catch (error) {
+    } catch (error: unknown) {
       console.error('标题生成失败:', error);
-      throw new BadRequestException(`标题生成失败: ${error.message}`);
+      const message = error instanceof Error ? error.message : String(error);
+      throw new BadRequestException(`标题生成失败: ${message}`);
     }
   }
 
@@ -84,11 +102,11 @@ export class HeadlineService {
    */
   private buildPrompt(dto: GenerateHeadlineDto): string {
     let prompt = `请为以下主题生成${dto.count || 5}个吸引人的标题:\n\n主题: ${dto.topic}`;
-    
+
     if (dto.keywords) {
       prompt += `\n关键词: ${dto.keywords}`;
     }
-    
+
     if (dto.platform) {
       const platformTips = {
         youtube: '适合YouTube视频，需要吸引点击',
@@ -100,7 +118,7 @@ export class HeadlineService {
       };
       prompt += `\n平台: ${dto.platform} (${platformTips[dto.platform] || '通用平台'})`;
     }
-    
+
     if (dto.tone) {
       const toneTips = {
         professional: '专业严肃的语调',
@@ -111,9 +129,9 @@ export class HeadlineService {
       };
       prompt += `\n语调: ${toneTips[dto.tone] || '自然语调'}`;
     }
-    
+
     prompt += '\n\n请生成标题，每个标题单独一行，不要添加序号或其他格式。';
-    
+
     return prompt;
   }
 
@@ -127,14 +145,14 @@ export class HeadlineService {
     // 按行分割并清理
     const lines = content
       .split('\n')
-      .map(line => line.trim())
-      .filter(line => line.length > 0)
-      .map(line => {
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0)
+      .map((line) => {
         // 移除可能的序号前缀
         return line.replace(/^\d+[.)\s]+/, '').trim();
       })
-      .filter(line => line.length > 0);
-    
+      .filter((line) => line.length > 0);
+
     // 返回指定数量的标题
     return lines.slice(0, count);
   }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -5,10 +5,10 @@ import { ConfigService } from './config/config.service';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  
+
   // 获取配置服务
   const configService = app.get(ConfigService);
-  
+
   // 启用全局验证管道
   app.useGlobalPipes(
     new ValidationPipe({
@@ -17,7 +17,7 @@ async function bootstrap() {
       forbidNonWhitelisted: true,
     }),
   );
-  
+
   // 启用CORS
   app.enableCors({
     origin: configService.corsOrigin,
@@ -25,13 +25,17 @@ async function bootstrap() {
     allowedHeaders: ['Content-Type', 'Authorization'],
     credentials: true,
   });
-  
+
   const port = configService.port;
   await app.listen(port);
-  
+
   console.log(`🚀 后端服务已启动: http://localhost:${port}`);
-  console.log(`📝 标题生成器API: http://localhost:${port}/api/headlines/generate`);
+  console.log(
+    `📝 标题生成器API: http://localhost:${port}/api/headlines/generate`,
+  );
   console.log(`🖼️ 缩略图API: http://localhost:${port}/api/thumbnail`);
 }
 
-bootstrap();
+bootstrap().catch((error) => {
+  console.error('应用启动失败:', error);
+});

--- a/backend/src/thumbnail/dto/thumbnail-request.dto.ts
+++ b/backend/src/thumbnail/dto/thumbnail-request.dto.ts
@@ -1,0 +1,12 @@
+import { IsUrl } from 'class-validator';
+
+/**
+ * 缩略图请求参数
+ */
+export class ThumbnailRequestDto {
+  /**
+   * 视频链接
+   */
+  @IsUrl({}, { message: '视频链接必须是有效的URL' })
+  url: string;
+}

--- a/backend/src/thumbnail/thumbnail.controller.ts
+++ b/backend/src/thumbnail/thumbnail.controller.ts
@@ -1,14 +1,18 @@
-import { Controller } from '@nestjs/common';
-import { Get } from '@nestjs/common';
-import { Query } from '@nestjs/common';
-import { HttpException } from '@nestjs/common';
-import { HttpStatus } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Query,
+  HttpException,
+  HttpStatus,
+  ValidationPipe,
+} from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { ApiOperation } from '@nestjs/swagger';
 import { ApiQuery } from '@nestjs/swagger';
 import { ApiResponse } from '@nestjs/swagger';
 import { ThumbnailService } from './thumbnail.service';
 import { ThumbnailResponseDto } from './dto/thumbnail-response.dto';
+import { ThumbnailRequestDto } from './dto/thumbnail-request.dto';
 
 @ApiTags('thumbnail')
 @Controller('api/thumbnail')
@@ -17,45 +21,50 @@ export class ThumbnailController {
 
   @Get()
   @ApiOperation({ summary: '获取视频封面缩略图' })
-  @ApiQuery({ name: 'url', description: '视频链接', example: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' })
-  @ApiResponse({ status: 200, description: '成功获取缩略图', type: ThumbnailResponseDto })
+  @ApiQuery({
+    name: 'url',
+    description: '视频链接',
+    example: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '成功获取缩略图',
+    type: ThumbnailResponseDto,
+  })
   @ApiResponse({ status: 400, description: '无效的视频链接' })
   @ApiResponse({ status: 404, description: '视频不存在或无法访问' })
   @ApiResponse({ status: 500, description: '服务器内部错误' })
-  async getThumbnail(@Query('url') url: string): Promise<ThumbnailResponseDto> {
-    if (!url) {
-      throw new HttpException(
-        {
-          success: false,
-          error: {
-            code: 'MISSING_URL',
-            message: '缺少视频链接参数'
-          }
-        },
-        HttpStatus.BAD_REQUEST
-      );
-    }
+  /**
+   * 获取视频缩略图
+   * @param {ThumbnailRequestDto} query - 请求参数
+   * @returns {ThumbnailResponseDto} 缩略图信息
+   */
+  getThumbnail(
+    @Query(new ValidationPipe({ transform: true, whitelist: true }))
+    query: ThumbnailRequestDto,
+  ): ThumbnailResponseDto {
+    const { url } = query;
 
     try {
-      const thumbnailData = await this.thumbnailService.extractThumbnails(url);
+      const thumbnailData = this.thumbnailService.extractThumbnails(url);
       return {
         success: true,
-        data: thumbnailData
+        data: thumbnailData,
       };
     } catch (error) {
       if (error instanceof HttpException) {
         throw error;
       }
-      
+
       throw new HttpException(
         {
           success: false,
           error: {
             code: 'EXTRACTION_FAILED',
-            message: '缩略图提取失败'
-          }
+            message: '缩略图提取失败',
+          },
         },
-        HttpStatus.INTERNAL_SERVER_ERROR
+        HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
   }
@@ -63,11 +72,15 @@ export class ThumbnailController {
   @Get('health')
   @ApiOperation({ summary: '健康检查' })
   @ApiResponse({ status: 200, description: '服务正常' })
+  /**
+   * 健康检查
+   * @returns {{ status: string; timestamp: string; service: string }} 服务状态
+   */
   getHealth() {
     return {
       status: 'ok',
       timestamp: new Date().toISOString(),
-      service: 'thumbnail-extractor'
+      service: 'thumbnail-extractor',
     };
   }
 }

--- a/backend/src/thumbnail/thumbnail.service.ts
+++ b/backend/src/thumbnail/thumbnail.service.ts
@@ -5,10 +5,12 @@ import { ThumbnailData } from './dto/thumbnail-response.dto';
 export class ThumbnailService {
   /**
    * 提取视频缩略图
+   * @param {string} url - 视频链接
+   * @returns {ThumbnailData} 缩略图数据
    */
-  async extractThumbnails(url: string): Promise<ThumbnailData> {
+  extractThumbnails(url: string): ThumbnailData {
     const platform = this.detectPlatform(url);
-    
+
     switch (platform) {
       case 'youtube':
         return this.extractYouTubeThumbnails(url);
@@ -20,16 +22,18 @@ export class ThumbnailService {
             success: false,
             error: {
               code: 'UNSUPPORTED_PLATFORM',
-              message: '不支持的视频平台'
-            }
+              message: '不支持的视频平台',
+            },
           },
-          HttpStatus.BAD_REQUEST
+          HttpStatus.BAD_REQUEST,
         );
     }
   }
 
   /**
    * 检测视频平台
+   * @param {string} url - 视频链接
+   * @returns {string} 平台名称
    */
   private detectPlatform(url: string): string {
     if (url.includes('youtube.com') || url.includes('youtu.be')) {
@@ -43,13 +47,15 @@ export class ThumbnailService {
 
   /**
    * 提取YouTube视频ID
+   * @param {string} url - YouTube链接
+   * @returns {string} 视频ID
    */
   private extractYouTubeVideoId(url: string): string {
     const patterns = [
       /(?:youtube\.com\/watch\?v=)([\w-]+)/,
       /(?:youtube\.com\/embed\/)([\w-]+)/,
       /(?:youtu\.be\/)([\w-]+)/,
-      /(?:youtube\.com\/v\/)([\w-]+)/
+      /(?:youtube\.com\/v\/)([\w-]+)/,
     ];
 
     for (const pattern of patterns) {
@@ -64,19 +70,21 @@ export class ThumbnailService {
         success: false,
         error: {
           code: 'INVALID_YOUTUBE_URL',
-          message: '无效的YouTube视频链接'
-        }
+          message: '无效的YouTube视频链接',
+        },
       },
-      HttpStatus.BAD_REQUEST
+      HttpStatus.BAD_REQUEST,
     );
   }
 
   /**
    * 提取YouTube缩略图
+   * @param {string} url - YouTube链接
+   * @returns {ThumbnailData} 缩略图数据
    */
-  private async extractYouTubeThumbnails(url: string): Promise<ThumbnailData> {
+  private extractYouTubeThumbnails(url: string): ThumbnailData {
     const videoId = this.extractYouTubeVideoId(url);
-    
+
     return {
       platform: 'youtube',
       videoId,
@@ -84,18 +92,20 @@ export class ThumbnailService {
         default: `https://img.youtube.com/vi/${videoId}/default.jpg`,
         medium: `https://img.youtube.com/vi/${videoId}/mqdefault.jpg`,
         high: `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`,
-        maxres: `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`
-      }
+        maxres: `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`,
+      },
     };
   }
 
   /**
    * 提取Bilibili视频ID
+   * @param {string} url - Bilibili链接
+   * @returns {string} 视频ID
    */
   private extractBilibiliVideoId(url: string): string {
     const patterns = [
       /(?:bilibili\.com\/video\/)([\w-]+)/,
-      /(?:b23\.tv\/)([\w-]+)/
+      /(?:b23\.tv\/)([\w-]+)/,
     ];
 
     for (const pattern of patterns) {
@@ -110,19 +120,21 @@ export class ThumbnailService {
         success: false,
         error: {
           code: 'INVALID_BILIBILI_URL',
-          message: '无效的Bilibili视频链接'
-        }
+          message: '无效的Bilibili视频链接',
+        },
       },
-      HttpStatus.BAD_REQUEST
+      HttpStatus.BAD_REQUEST,
     );
   }
 
   /**
    * 提取Bilibili缩略图
+   * @param {string} url - Bilibili链接
+   * @returns {ThumbnailData} 缩略图数据
    */
-  private async extractBilibiliThumbnails(url: string): Promise<ThumbnailData> {
+  private extractBilibiliThumbnails(url: string): ThumbnailData {
     const videoId = this.extractBilibiliVideoId(url);
-    
+
     // 注意：Bilibili的缩略图需要通过API获取，这里提供基础结构
     // 实际项目中需要调用Bilibili API获取真实的缩略图URL
     return {
@@ -132,8 +144,8 @@ export class ThumbnailService {
         default: `https://i0.hdslb.com/bfs/archive/${videoId}.jpg`,
         medium: `https://i0.hdslb.com/bfs/archive/${videoId}.jpg@320w_200h_1c.webp`,
         high: `https://i0.hdslb.com/bfs/archive/${videoId}.jpg@480w_300h_1c.webp`,
-        maxres: `https://i0.hdslb.com/bfs/archive/${videoId}.jpg@720w_450h_1c.webp`
-      }
+        maxres: `https://i0.hdslb.com/bfs/archive/${videoId}.jpg@720w_450h_1c.webp`,
+      },
     };
   }
 }


### PR DESCRIPTION
## Summary
- add stricter count validation for headline generator
- validate thumbnail API request with DTO and JSDoc
- improve error handling and startup logging

## Testing
- `pnpm lint` *(fails: Cannot read properties of undefined (reading 'allowShortCircuit'))*
- `pnpm lint:backend`
- `pnpm type-check` *(fails: Missing script: "type-check" in frontend)*
- `pnpm type-check:backend`


------
https://chatgpt.com/codex/tasks/task_e_68b94158eafc8328aee884373c3cac69